### PR TITLE
Support developer authentication flow in bananas-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+.env/

--- a/bananas_cli/cli.py
+++ b/bananas_cli/cli.py
@@ -18,9 +18,10 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 )
 @click.option("--tus-url", help="BaNaNaS tus URL. (normally the same as --api-url)", metavar="URL")
 @click.option("--client-id", help="Client-id to use for authentication", default="ape", show_default=True)
+@click.option("--audience", help="Audience to use for authentication", default="github", show_default=False)
 @click.pass_context
 @task
-async def cli(ctx, api_url, tus_url, client_id):
+async def cli(ctx, api_url, tus_url, client_id, audience):
     """
     A CLI tool to list, upload, and otherwise modify BaNaNaS content.
 
@@ -43,7 +44,7 @@ async def cli(ctx, api_url, tus_url, client_id):
     ctx.obj = session
 
     await session.start()
-    await authenticate(session, client_id)
+    await authenticate(session, client_id, audience)
 
 
 @task

--- a/bananas_cli/session.py
+++ b/bananas_cli/session.py
@@ -27,6 +27,8 @@ class Session:
 
     async def _read_response(self, response):
         if response.status in (200, 201, 400, 404):
+            if response.content_type == "text/html":
+                return 302, response.url
             data = await response.json()
         elif response.status in (301, 302):
             data = response.headers["Location"]


### PR DESCRIPTION
While setting up my dev environment for bananas, I had trouble authenticating to the API. 

- I've allowed the audience to be configurable (kept the default to be github). 
- The postback to get the token was always requested with the hardcoded client_id `ape`, so I made that configurable as well. 
- If we get a success code, but the mime type is `text/html`, I assume it should have been a 302 with the request URL instead. Parsing the response as json will definitely crash, so it will not deteriorate the experience very much. Ideally the bananas-api would actually return the 302, but on that side I did not see a straightforward way to make a difference between an automated request from the cli and a browser request (perhaps that will come as my python skills increase).
- Finally, added `.env` to `.gitignore` for obvious reasons ;) 