### PR TITLE
Allow connecting to developer-endpoint of bananas api

### DIFF
--- a/bananas_cli/authentication.py
+++ b/bananas_cli/authentication.py
@@ -78,7 +78,7 @@ class Authenticate:
             raise Exit
 
 
-async def authenticate(session, client_id):
+async def authenticate(session):
     config_folder = click.get_app_dir("bananas-cli")
     os.makedirs(config_folder, exist_ok=True)
     token_filename = config_folder + "/token"
@@ -104,7 +104,7 @@ async def authenticate(session, client_id):
         "audience=github&"
         "redirect_uri=http%3A%2F%2Flocalhost%3A3977%2F&"
         "response_type=code&"
-        f"client_id={client_id}&"
+        f"client_id={Authenticate.client_id}&"
         f"code_challenge={code_challenge}&"
         "code_challenge_method=S256"
     )

--- a/bananas_cli/authentication.py
+++ b/bananas_cli/authentication.py
@@ -26,6 +26,8 @@ class Authenticate:
     session = None
     token_filename = None
     success = False
+    client_id = None
+    audience = None
 
     @staticmethod
     @routes.get("/")
@@ -35,7 +37,7 @@ class Authenticate:
             status, data = await Authenticate.session.post(
                 "/user/token",
                 json={
-                    "client_id": "ape",
+                    "client_id": Authenticate.client_id,
                     "redirect_uri": "http://localhost:3977/",
                     "code_verifier": Authenticate.code_verifier,
                     "code": code,
@@ -101,7 +103,7 @@ async def authenticate(session):
 
     status, data = await session.get(
         "/user/authorize?"
-        "audience=github&"
+        f"audience={Authenticate.audience}&"
         "redirect_uri=http%3A%2F%2Flocalhost%3A3977%2F&"
         "response_type=code&"
         f"client_id={Authenticate.client_id}&"
@@ -112,6 +114,8 @@ async def authenticate(session):
         log.error(f"Server returned invalid status code {status}. Authentication failed. Error: {data}")
         raise Exit
 
+    if data.startswith("/"):
+        data = f"{session.api_url}{data}"
     print("Please visit the following URL to authenticate:")
     print(f"  {data}")
 

--- a/bananas_cli/cli.py
+++ b/bananas_cli/cli.py
@@ -18,9 +18,10 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 )
 @click.option("--tus-url", help="BaNaNaS tus URL. (normally the same as --api-url)", metavar="URL")
 @click.option("--client-id", help="Client-id to use for authentication", default="ape", show_default=True)
+@click.option("--audience", help="Audience to use for authentication", default="github", show_default=True)
 @click.pass_context
 @task
-async def cli(ctx, api_url, tus_url, client_id):
+async def cli(ctx, api_url, tus_url, client_id, audience):
     """
     A CLI tool to list, upload, and otherwise modify BaNaNaS content.
 
@@ -44,6 +45,7 @@ async def cli(ctx, api_url, tus_url, client_id):
 
     await session.start()
     Authenticate.client_id = client_id
+    Authenticate.audience = audience
 
 
 @task

--- a/bananas_cli/cli.py
+++ b/bananas_cli/cli.py
@@ -1,7 +1,7 @@
 import click
 import logging
 
-from .authentication import authenticate
+from .authentication import Authenticate
 from .helpers import task
 from .session import Session
 
@@ -43,7 +43,7 @@ async def cli(ctx, api_url, tus_url, client_id):
     ctx.obj = session
 
     await session.start()
-    await authenticate(session, client_id)
+    Authenticate.client_id = client_id
 
 
 @task

--- a/bananas_cli/commands/list_self.py
+++ b/bananas_cli/commands/list_self.py
@@ -6,6 +6,7 @@ from ..cli import (
 )
 from ..exceptions import Exit
 from ..helpers import task
+from ..authentication import authenticate
 
 log = logging.getLogger(__name__)
 
@@ -14,6 +15,8 @@ log = logging.getLogger(__name__)
 @pass_session
 @task
 async def list_self(session):
+    await authenticate(session)
+
     status, data = await session.get("/package/self")
     if status != 200:
         log.error(f"Server returned invalid status code {status}: {data}")

--- a/bananas_cli/commands/upload.py
+++ b/bananas_cli/commands/upload.py
@@ -8,6 +8,7 @@ from ..cli import (
 from ..enums import License
 from ..exceptions import Exit
 from ..helpers import task
+from ..authentication import authenticate
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ def show_validation_errors(data):
 @pass_session
 @task
 async def upload(session, version, name, description, url, license, files):
+    await authenticate(session)
+
     parts = files[0].split("/")[:-1]
     for filename in files:
         check_parts = filename.split("/")


### PR DESCRIPTION
Based on #21 and also OpenTTD/bananas-api#88

* OpenTTD/bananas-api#88 introduced the same redirect flow for developer login as we have for github login. 
* #21 changed the login flow on the clientside to be handled in the actual commands instead of on startup. @TrueBrain did mention on IRC he is interested in authentication using decorators instead, but in my opinion that is not a priority for a one-liner.

In this PR I allow the user to set the oauth audience (previously hardcoded) to 'developer', and replace a hard-coded client id with the already configurable one. Finally, if the redirect url is a relative url (starting with /), the api-url is prepended. 

Together with the changes on the bananas-api server side, this allows a user to use developer authentication. 